### PR TITLE
use set basic auth code when connecting to elasticsearch

### DIFF
--- a/repository/elasticsearch.go
+++ b/repository/elasticsearch.go
@@ -68,8 +68,8 @@ func createClient(repo *config.Repository) (*elastic.Client, error) {
 		c.Password = repo.Password
 	}
 
-	//client, err := elastic.NewClient(elastic.SetURL(esURL), elastic.SetBasicAuth(repo.Username, repo.Password), elastic.SetSniff(false))
-	client, err := elastic.NewClientFromConfig(&c)
+	client, err := elastic.NewClient(elastic.SetURL(esURL), elastic.SetBasicAuth(repo.Username, repo.Password), elastic.SetSniff(false))
+	//client, err := elastic.NewClientFromConfig(&c)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When testing the basic authentication it seemed to have the same issues. Looking at the code it looks like we were not using the setBasicAuth func in master as it was commented out. Uncommenting and test works. 